### PR TITLE
Fixed colors for "Swift for iOS" code.

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -94,7 +94,7 @@ export default function App() {
               color={color}
               lang="swift"
               title="Swift for iOS"
-              code={`UIColor(red: ${color.r / 100}, green: ${color.g / 100}, blue: ${color.b / 100}, alpha: ${
+              code={`UIColor(red: ${color.r / 255}, green: ${color.g / 255}, blue: ${color.b / 255}, alpha: ${
                 color.a
               })`}
             />


### PR DESCRIPTION
I tried to use your tool to fix my problem with RGB color, but it's not work correctly. RGB values have a range of 0-1. The numbers that are given are always divided by 255.

https://stackoverflow.com/questions/39557590/graphics-uicolor-created-with-component-values-far-outside-the-expected-range

Also I don't know about other Codes and I can't to check them.
Thank you :)