### PR TITLE
Fixed large numbers in the web page.

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -94,7 +94,7 @@ export default function App() {
               color={color}
               lang="swift"
               title="Swift for iOS"
-              code={`UIColor(red: ${color.r / 255}, green: ${color.g / 255}, blue: ${color.b / 255}, alpha: ${
+              code={`UIColor(red: ${color.r}/255, green: ${color.g}/255, blue: ${color.b}/255, alpha: ${
                 color.a
               })`}
             />


### PR DESCRIPTION
Unfortunately divided numbers looks not good.
```
UIColor(red: 0.4823529411764706, green: 0.43529411764705883, blue: 0.43137254901960786, alpha: 1)
```

It will look better with divide symbol.
```
UIColor(red: 123/255, green: 111/255, blue: 110/255, alpha: 1)
```

Can we use this instead of large number?)